### PR TITLE
Feat/#10 언어 매핑 테이블 수정, 사용자/상담사 분리, 센터 예약하기 조회 API 구현

### DIFF
--- a/src/main/java/com/example/helloworldmvc/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/helloworldmvc/apiPayload/code/status/ErrorStatus.java
@@ -30,7 +30,6 @@ ErrorStatus implements BaseErrorCode {
 
     // 센터 관련 응답
     CENTER_NOT_FOUND(HttpStatus.NOT_FOUND,"CENTER4001", "센터를 찾을수 없습니다."),
-    COUNSELOR_NOT_FOUND(HttpStatus.NOT_FOUND, "CENTER4002", "상담사를 찾을수 없습니다."),
     LANGUAGE_NOT_MATCHING(HttpStatus.NOT_FOUND, "CENTER4003", "해당 언어의 상담사가 없습니다.");
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/helloworldmvc/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/helloworldmvc/apiPayload/code/status/ErrorStatus.java
@@ -23,7 +23,9 @@ ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER4001", "사용자를 찾을수 없습니다."),
 
     // 센터 관련 응답
-    CENTER_NOT_FOUND(HttpStatus.NOT_FOUND,"CENTER4001", "센터를 찾을수 없습니다.");
+    CENTER_NOT_FOUND(HttpStatus.NOT_FOUND,"CENTER4001", "센터를 찾을수 없습니다."),
+    COUNSELOR_NOT_FOUND(HttpStatus.NOT_FOUND, "CENTER4002", "상담사를 찾을수 없습니다."),
+    LANGUAGE_NOT_MATCHING(HttpStatus.NOT_FOUND, "CENTER4003", "해당 언어의 상담사가 없습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/example/helloworldmvc/converter/CenterConverter.java
+++ b/src/main/java/com/example/helloworldmvc/converter/CenterConverter.java
@@ -1,9 +1,11 @@
 package com.example.helloworldmvc.converter;
 
 import com.example.helloworldmvc.domain.Center;
+import com.example.helloworldmvc.domain.Counselor;
 import com.example.helloworldmvc.web.dto.CenterResponseDTO;
 import org.springframework.data.domain.Page;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,6 +27,24 @@ public class CenterConverter {
                 .map(CenterConverter::toCenterMapRes).collect(Collectors.toList());
         return CenterResponseDTO.CenterMapListRes.builder()
                 .centerMapList(centerMapRes)
+                .build();
+    }
+
+    public static CenterResponseDTO.CounselorListRes toCounselorListRes(Page<Counselor> counselorList) {
+        List<CenterResponseDTO.CounselorRes> counselorResList = counselorList.stream()
+                .map(CenterConverter::toCounselorRes).collect(Collectors.toList());
+        return CenterResponseDTO.CounselorListRes.builder()
+                .today(LocalDateTime.now())
+                .counselorList(counselorResList)
+                .build();
+    }
+    public static CenterResponseDTO.CounselorRes toCounselorRes(Counselor counselor) {
+        return CenterResponseDTO.CounselorRes.builder()
+                .name(counselor.getName())
+                .centerName(counselor.getCenter().getName())
+                .language(counselor.getCounselorLanguageList().stream().map(s -> s.getLanguage().getName()).collect(Collectors.toList()))
+                .start(counselor.getStart())
+                .end(counselor.getEnd())
                 .build();
     }
 }

--- a/src/main/java/com/example/helloworldmvc/domain/Counselor.java
+++ b/src/main/java/com/example/helloworldmvc/domain/Counselor.java
@@ -1,8 +1,7 @@
 package com.example.helloworldmvc.domain;
 
-import com.example.helloworldmvc.domain.enums.UserLanguage;
-import com.example.helloworldmvc.domain.mapping.AvailableLanguage;
-import com.example.helloworldmvc.domain.mapping.Reservation;
+import com.example.helloworldmvc.domain.mapping.CounselorLanguage;
+import com.example.helloworldmvc.domain.mapping.UserLanguage;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -34,6 +33,8 @@ public class Counselor {
     @JoinColumn(name = "center_id")
     private Center center;
 
-    @OneToMany(mappedBy = "counselor")
-    private List<AvailableLanguage> availableLanguageList = new ArrayList<>();
+    @OneToMany(mappedBy = "counselor", cascade = CascadeType.ALL)
+    private List<CounselorLanguage> counselorLanguageList = new ArrayList<>();
+
+
 }

--- a/src/main/java/com/example/helloworldmvc/domain/Language.java
+++ b/src/main/java/com/example/helloworldmvc/domain/Language.java
@@ -1,6 +1,7 @@
 package com.example.helloworldmvc.domain;
 
-import com.example.helloworldmvc.domain.mapping.AvailableLanguage;
+import com.example.helloworldmvc.domain.mapping.CounselorLanguage;
+import com.example.helloworldmvc.domain.mapping.UserLanguage;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,6 +20,9 @@ public class Language {
     @Column(nullable = false, length = 10)
     private String name;
 
-    @OneToMany(mappedBy = "language", fetch = FetchType.LAZY)
-    private List<AvailableLanguage> availableLanguages = new ArrayList<>();
+    @OneToMany(mappedBy = "language", cascade = CascadeType.ALL)
+    private List<UserLanguage> userLanguages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "language", cascade = CascadeType.ALL)
+    private List<CounselorLanguage> counselorLanguages = new ArrayList<>();
 }

--- a/src/main/java/com/example/helloworldmvc/domain/User.java
+++ b/src/main/java/com/example/helloworldmvc/domain/User.java
@@ -1,8 +1,7 @@
 package com.example.helloworldmvc.domain;
 
 import com.example.helloworldmvc.domain.common.BaseEntity;
-import com.example.helloworldmvc.domain.enums.UserLanguage;
-import com.example.helloworldmvc.domain.mapping.AvailableLanguage;
+import com.example.helloworldmvc.domain.mapping.UserLanguage;
 import com.example.helloworldmvc.domain.mapping.Reservation;
 import jakarta.persistence.*;
 import lombok.*;
@@ -35,6 +34,7 @@ public class User extends BaseEntity {
     private List<Reservation> reservationList = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
-    private List<AvailableLanguage> availableLanguageList = new ArrayList<>();
+    private List<UserLanguage> userLanguageList = new ArrayList<>();
+
 }
 

--- a/src/main/java/com/example/helloworldmvc/domain/enums/UserLanguage.java
+++ b/src/main/java/com/example/helloworldmvc/domain/enums/UserLanguage.java
@@ -1,5 +1,0 @@
-package com.example.helloworldmvc.domain.enums;
-
-public enum UserLanguage {
-    ENGLISH, CHINESE, VIETNAMESE, FILIPINO, THAI
-}

--- a/src/main/java/com/example/helloworldmvc/domain/mapping/CounselorLanguage.java
+++ b/src/main/java/com/example/helloworldmvc/domain/mapping/CounselorLanguage.java
@@ -1,0 +1,25 @@
+package com.example.helloworldmvc.domain.mapping;
+
+import com.example.helloworldmvc.domain.Counselor;
+import com.example.helloworldmvc.domain.Language;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CounselorLanguage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "counselor_id")
+    private Counselor counselor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "language_id")
+    private Language language;
+
+}

--- a/src/main/java/com/example/helloworldmvc/domain/mapping/UserLanguage.java
+++ b/src/main/java/com/example/helloworldmvc/domain/mapping/UserLanguage.java
@@ -1,6 +1,5 @@
 package com.example.helloworldmvc.domain.mapping;
 
-import com.example.helloworldmvc.domain.Counselor;
 import com.example.helloworldmvc.domain.Language;
 import com.example.helloworldmvc.domain.User;
 import jakarta.persistence.*;
@@ -11,17 +10,13 @@ import lombok.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class AvailableLanguage {
+public class UserLanguage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "counselor_id")
-    private Counselor counselor;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "language_id")

--- a/src/main/java/com/example/helloworldmvc/repository/CounselorLanguageRepository.java
+++ b/src/main/java/com/example/helloworldmvc/repository/CounselorLanguageRepository.java
@@ -1,0 +1,7 @@
+package com.example.helloworldmvc.repository;
+
+import com.example.helloworldmvc.domain.mapping.CounselorLanguage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CounselorLanguageRepository extends JpaRepository<CounselorLanguage, Long> {
+}

--- a/src/main/java/com/example/helloworldmvc/repository/CounselorRepository.java
+++ b/src/main/java/com/example/helloworldmvc/repository/CounselorRepository.java
@@ -1,0 +1,16 @@
+package com.example.helloworldmvc.repository;
+
+import com.example.helloworldmvc.domain.Counselor;
+import com.example.helloworldmvc.domain.mapping.CounselorLanguage;
+import com.example.helloworldmvc.domain.mapping.UserLanguage;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface CounselorRepository extends JpaRepository<Counselor, Long> {
+    @Query("SELECT DISTINCT c FROM Counselor c JOIN c.counselorLanguageList l WHERE l.id IN :userLanguageList")
+    Page<Counselor> findAllByCounselorLanguageList(List<Long> userLanguageList, Pageable pageable);
+}

--- a/src/main/java/com/example/helloworldmvc/repository/LanguageRepository.java
+++ b/src/main/java/com/example/helloworldmvc/repository/LanguageRepository.java
@@ -1,0 +1,7 @@
+package com.example.helloworldmvc.repository;
+
+import com.example.helloworldmvc.domain.Language;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LanguageRepository extends JpaRepository<Language, Long> {
+}

--- a/src/main/java/com/example/helloworldmvc/service/CenterService.java
+++ b/src/main/java/com/example/helloworldmvc/service/CenterService.java
@@ -1,8 +1,11 @@
 package com.example.helloworldmvc.service;
 
 import com.example.helloworldmvc.domain.Center;
+import com.example.helloworldmvc.domain.Counselor;
 import org.springframework.data.domain.Page;
 
 public interface CenterService {
     Page<Center> getCenterList(Long userId, Integer page, Integer size);
+
+    Page<Counselor> getCounselorList(Long userId, Integer page, Integer size);
 }

--- a/src/main/java/com/example/helloworldmvc/service/CenterServiceImpl.java
+++ b/src/main/java/com/example/helloworldmvc/service/CenterServiceImpl.java
@@ -3,13 +3,18 @@ package com.example.helloworldmvc.service;
 import com.example.helloworldmvc.apiPayload.GeneralException;
 import com.example.helloworldmvc.apiPayload.code.status.ErrorStatus;
 import com.example.helloworldmvc.domain.Center;
-import com.example.helloworldmvc.repository.CenterRepository;
-import com.example.helloworldmvc.repository.UserRepository;
+import com.example.helloworldmvc.domain.Counselor;
+import com.example.helloworldmvc.domain.User;
+import com.example.helloworldmvc.domain.mapping.UserLanguage;
+import com.example.helloworldmvc.repository.*;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,9 +23,20 @@ public class CenterServiceImpl implements CenterService{
 
     private final UserRepository userRepository;
     private final CenterRepository centerRepository;
+    private final LanguageRepository languageRepository;
+    private final CounselorRepository counselorRepository;
     @Override
     public Page<Center> getCenterList(Long userId, Integer page, Integer size) {
         userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         return centerRepository.findAll(PageRequest.of(page, size));
+    }
+
+    @Override
+    public Page<Counselor> getCounselorList(Long userId, Integer page, Integer size) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        List<Long> languageId = user.getUserLanguageList().stream()
+                .map(language -> language.getLanguage().getId()).collect(Collectors.toList());
+        return counselorRepository.findAllByCounselorLanguageList(languageId, PageRequest.of(page, size));
+
     }
 }

--- a/src/main/java/com/example/helloworldmvc/web/controller/CenterController.java
+++ b/src/main/java/com/example/helloworldmvc/web/controller/CenterController.java
@@ -3,7 +3,9 @@ package com.example.helloworldmvc.web.controller;
 import com.example.helloworldmvc.apiPayload.ApiResponse;
 import com.example.helloworldmvc.converter.CenterConverter;
 import com.example.helloworldmvc.domain.Center;
+import com.example.helloworldmvc.domain.Counselor;
 import com.example.helloworldmvc.service.CenterService;
+import com.example.helloworldmvc.web.dto.CenterResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class CenterController {
 
     private final CenterService centerService;
+
     @GetMapping("/")
     @Operation(summary = "센터 조회 API", description = "지도에서 센터 위치와 정보를 조회하는 API입니다.")
     @ApiResponses({
@@ -31,11 +34,30 @@ public class CenterController {
             @Parameter(name = "page", description = "query string(RequestParam) - 몇번째 페이지인지 가리키는 page 변수 (0부터 시작)"),
             @Parameter(name = "size", description = "query string(RequestParam) - 몇 개씩 불러올지 개수를 세는 변수 (1 이상 자연수로 설정)")
     })
-    public ApiResponse<?> getCenter(@RequestHeader("user_id") Long userId,
-                                    @RequestParam(name = "page") Integer page,
-                                    @RequestParam(name = "size") Integer size){
+    public ApiResponse<CenterResponseDTO.CenterMapListRes> getCenter(@RequestHeader("user_id") Long userId,
+                                                                     @RequestParam(name = "page") Integer page,
+                                                                     @RequestParam(name = "size") Integer size) {
         Page<Center> centerList = centerService.getCenterList(userId, page, size);
         return ApiResponse.onSuccess(CenterConverter.toCenterMapListRes(centerList));
+    }
+
+    @GetMapping("/{center_id}/reservation")
+    @Operation(summary = "센터 예약하기 조회 API", description = "해당 센터의 언어에 맞는 상담사 리스트와 현재 날짜를 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CENTER4001", description = "센터를 찾을수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "CENTER4002", description = "상담사를 찾을수 없습니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameters({
+            @Parameter(name = "user_id", description = "RequestHeader - 로그인한 사용자 아이디(accessToken으로 변경 예정)"),
+            @Parameter(name = "page", description = "query string(RequestParam) - 몇번째 페이지인지 가리키는 page 변수 (0부터 시작)"),
+            @Parameter(name = "size", description = "query string(RequestParam) - 몇 개씩 불러올지 개수를 세는 변수 (1 이상 자연수로 설정)")
+    })
+    public ApiResponse<CenterResponseDTO.CounselorListRes> getCenterReservation(@RequestHeader("user_id") Long userId,
+                                               @RequestParam(name = "page") Integer page,
+                                               @RequestParam(name = "size") Integer size){
+        Page<Counselor> counselorList = centerService.getCounselorList(userId, page, size);
+        return ApiResponse.onSuccess(CenterConverter.toCounselorListRes(counselorList));
     }
 
 }

--- a/src/main/java/com/example/helloworldmvc/web/dto/CenterResponseDTO.java
+++ b/src/main/java/com/example/helloworldmvc/web/dto/CenterResponseDTO.java
@@ -1,5 +1,6 @@
 package com.example.helloworldmvc.web.dto;
 
+import com.example.helloworldmvc.domain.Language;
 import com.example.helloworldmvc.domain.enums.CenterStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,5 +33,25 @@ public class CenterResponseDTO {
         String image;
         Double latitude;
         Double longitude;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CounselorListRes {
+        LocalDateTime today;
+        List<CounselorRes> counselorList;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CounselorRes {
+        String name;
+        String centerName;
+        List<String> language;
+        LocalDateTime start;
+        LocalDateTime end;
     }
 }


### PR DESCRIPTION
## 개요
센터 예약하기 조회 API 구현
## 작업사항
API 구현 및 엔티티 수정
## 변경로직
mapping 테이블 변경
### 변경 전
AvailableLanguage 테이블
### 변경 후
UserLanguage, CounselorLanguage 테이블 두개로 분리 (외래 키 제약 때문)
## 사용방법
<img width="1509" alt="image" src="https://github.com/user-attachments/assets/898d45cb-c381-4a1f-8916-ff778d691c7f">
언어 필터 조건에 하나라도 해당되면 상담사 조회가능
## 기타
