### PR TITLE
[feat/#116] 커뮤니티 글 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/example/helloworldmvc/converter/CommunityConverter.java
+++ b/src/main/java/com/example/helloworldmvc/converter/CommunityConverter.java
@@ -1,5 +1,6 @@
 package com.example.helloworldmvc.converter;
 
+import com.example.helloworldmvc.domain.Comment;
 import com.example.helloworldmvc.domain.Community;
 import com.example.helloworldmvc.domain.enums.CommunityCategory;
 import com.example.helloworldmvc.web.dto.CommunityRequestDTO;
@@ -39,10 +40,35 @@ public class CommunityConverter {
             imageUrl = community.getFileList().get(0).getUrl();
         }
         return CommunityResponseDTO.PostDTO.builder()
+                .post_id(community.getId())
                 .title(community.getTitle())
                 .created_at(community.getCreatedAt())
                 .commentNum(community.getCommentList().size())
                 .imageUrl(imageUrl)
+                .build();
+    }
+
+    public static CommunityResponseDTO.PostDetailDTO toPostDetailDTO(Community community, Page<Comment> commentList){
+        List<String> list = new ArrayList<>();
+        if(!community.getFileList().isEmpty()){
+            community.getFileList().stream().map(file -> list.add(file.getUrl())).collect(Collectors.toList());
+        }
+        else list.add("NULL");
+        List<CommunityResponseDTO.CommentDTO> comments = commentList.stream().map(CommunityConverter::toCommentDTO).toList();
+        return CommunityResponseDTO.PostDetailDTO.builder()
+                .title(community.getTitle())
+                .content(community.getContent())
+                .created_at(community.getCreatedAt())
+                .fileList(list)
+                .commentDTOList(comments)
+                .build();
+    }
+
+    public static CommunityResponseDTO.CommentDTO toCommentDTO(Comment comment){
+        return CommunityResponseDTO.CommentDTO.builder()
+                .anonymousName(comment.getAnonymous())
+                .created_at(comment.getCreatedAt())
+                .content(comment.getContent())
                 .build();
     }
     public static CommunityCategory toCommunityCategory(Long categoryId){

--- a/src/main/java/com/example/helloworldmvc/domain/Comment.java
+++ b/src/main/java/com/example/helloworldmvc/domain/Comment.java
@@ -16,6 +16,8 @@ public class Comment extends BaseEntity {
 
     @Column(nullable = false)
     private String content;
+    @Column(nullable = false)
+    private Long anonymous;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/example/helloworldmvc/service/CommunityService.java
+++ b/src/main/java/com/example/helloworldmvc/service/CommunityService.java
@@ -10,4 +10,5 @@ public interface CommunityService {
 
     CommunityResponseDTO.CreatedPostDTO createCommunityPost(String userId, Long categoryId, CommunityRequestDTO.CreatePostDTO request);
     CommunityResponseDTO.PostListDTO getCommunityList(String userId, Long categoryId, Integer page, Integer size);
+    CommunityResponseDTO.PostDetailDTO getCommunityDetail(String userId, Long communityId, Integer page, Integer size);
 }

--- a/src/main/java/com/example/helloworldmvc/service/CommunityServiceImpl.java
+++ b/src/main/java/com/example/helloworldmvc/service/CommunityServiceImpl.java
@@ -3,6 +3,7 @@ package com.example.helloworldmvc.service;
 import com.example.helloworldmvc.apiPayload.GeneralException;
 import com.example.helloworldmvc.apiPayload.code.status.ErrorStatus;
 import com.example.helloworldmvc.converter.CommunityConverter;
+import com.example.helloworldmvc.domain.Comment;
 import com.example.helloworldmvc.domain.Community;
 import com.example.helloworldmvc.domain.File;
 import com.example.helloworldmvc.domain.User;
@@ -14,10 +15,13 @@ import com.example.helloworldmvc.web.dto.CommunityRequestDTO;
 import com.example.helloworldmvc.web.dto.CommunityResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 
 @Service
@@ -48,5 +52,18 @@ public class CommunityServiceImpl implements CommunityService {
         CommunityCategory communityCategory = CommunityConverter.toCommunityCategory(categoryId);
         Page<Community> communityList = communityRepository.findAllByCommunityCategory(communityCategory, PageRequest.of(page, size));
         return CommunityConverter.toPostListDTO(communityList);
+    }
+
+    @Override
+    public CommunityResponseDTO.PostDetailDTO getCommunityDetail(String userId, Long communityId, Integer page, Integer size) {
+        User user = userRepository.findByEmail(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        Community community = communityRepository.findById(communityId).orElseThrow(() -> new GeneralException(ErrorStatus.COMMUNITY_POST_NOT_FOUND));
+        List<Comment> commentList = community.getCommentList();
+        PageRequest pageRequest = PageRequest.of(page, size);
+        int start = (int) pageRequest.getOffset();
+        int end = Math.min((start + pageRequest.getPageSize()), commentList.size());
+        List<Comment> subList = commentList.subList(start, end);
+        Page<Comment> commentPage = new PageImpl<>(subList, pageRequest, commentList.size());
+        return CommunityConverter.toPostDetailDTO(community, commentPage);
     }
 }

--- a/src/main/java/com/example/helloworldmvc/web/controller/CommunityController.java
+++ b/src/main/java/com/example/helloworldmvc/web/controller/CommunityController.java
@@ -51,10 +51,33 @@ public class CommunityController {
             @Parameter(name = "size", description = "query string(RequestParam) - 몇 개씩 불러올지 개수를 세는 변수입니다. (1 이상 자연수로 설정)")
     })
     public ApiResponse<CommunityResponseDTO.PostListDTO> getCommunityList(@RequestHeader(name = "Authorization") String accessToken,
-                                           @PathVariable(name = "category_id") Long categoryId,
-                                           @RequestParam(name = "page") Integer page,
-                                           @RequestParam(name = "size") Integer size) {
+                                                                          @PathVariable(name = "category_id") Long categoryId,
+                                                                          @RequestParam(name = "page") Integer page,
+                                                                          @RequestParam(name = "size") Integer size) {
         String gmail = jwtTokenProvider.getGoogleEmail(accessToken);
         return ApiResponse.onSuccess(communityService.getCommunityList(gmail, categoryId, page, size));
+    }
+
+    @PostMapping(value = "/{category_id}/detail/{community_id}")
+    @Operation(summary = "커뮤니티 글 상세 조회 API", description = "커뮤니티 게시글을 상세 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER4001", description = "사용자를 찾을수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMUNITY4001", description = "커뮤니티 글이 존재하지 않습니다."),
+    })
+    @Parameters({
+            @Parameter(name = "Authorization", description = "RequestHeader - 로그인한 사용자 토큰"),
+            @Parameter(name = "category_id", description = "PathVariable - 게시글 카테고리 아이디"),
+            @Parameter(name = "community_id", description = "PathVariable - 게시글 아이디"),
+            @Parameter(name = "page", description = "query string(RequestParam) - 몇번째 페이지인지 가리키는 page 변수 입니다! (0부터 시작)"),
+            @Parameter(name = "size", description = "query string(RequestParam) - 몇 개씩 불러올지 개수를 세는 변수입니다. (1 이상 자연수로 설정)")
+    })
+    public ApiResponse<CommunityResponseDTO.PostDetailDTO> getCommunityDetail(@RequestHeader(name = "Authorization") String accessToken,
+                                                                           @PathVariable(name = "category_id") Long categoryId,
+                                                                           @PathVariable(name = "community_id") Long communityId,
+                                                                           @RequestParam(name = "page") Integer page,
+                                                                           @RequestParam(name = "size") Integer size) {
+        String gmail = jwtTokenProvider.getGoogleEmail(accessToken);
+        return ApiResponse.onSuccess(communityService.getCommunityDetail(gmail, communityId, page, size));
     }
 }

--- a/src/main/java/com/example/helloworldmvc/web/dto/CommunityResponseDTO.java
+++ b/src/main/java/com/example/helloworldmvc/web/dto/CommunityResponseDTO.java
@@ -29,9 +29,32 @@ public class CommunityResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class PostDTO{
+        Long post_id;
         String title;
         LocalDateTime created_at;
         Integer commentNum;
         String imageUrl;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostDetailDTO{
+        String title;
+        String content;
+        LocalDateTime created_at;
+        List<String> fileList;
+        List<CommentDTO> commentDTOList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentDTO{
+        Long anonymousName;
+        LocalDateTime created_at;
+        String content;
     }
 }


### PR DESCRIPTION
## 개요
커뮤니티 글 상세 조회 API 구현
## 작업사항

- 커뮤니티 글 상세 조회
- 파일이 없는 경우 NULL로 예외처리
- 댓글 목록 조회를 Page로 처리했습니다.

## 변경로직

### 변경 전

### 변경 후

## 사용방법

## 기타
