### PR TITLE
[Refactor] 내가 쓴 글 조회 API 수정

### DIFF
--- a/src/main/java/com/example/helloworldmvc/converter/MyPageConverter.java
+++ b/src/main/java/com/example/helloworldmvc/converter/MyPageConverter.java
@@ -110,12 +110,19 @@ public class MyPageConverter {
 
 
     public static MyPageResponseDTO.MyCommunityResDTO toMyCommunityRes(Community community) {
+        String imageUrl = null;
+        if (!community.getFileList().isEmpty()) {
+            imageUrl = community.getFileList().get(0).getUrl();
+        }
+
         return MyPageResponseDTO.MyCommunityResDTO.builder()
                 .communityId(community.getId())
                 .title(community.getTitle())
                 .content(community.getContent())
                 .uploadedAt(community.getCreatedAt())
                 .category(community.getCommunityCategory().name())
+                .commentCnt((long) community.getCommentList().size())
+                .imageUrl(imageUrl)
                 .build();
     }
 

--- a/src/main/java/com/example/helloworldmvc/domain/Community.java
+++ b/src/main/java/com/example/helloworldmvc/domain/Community.java
@@ -4,6 +4,7 @@ import com.example.helloworldmvc.domain.common.BaseEntity;
 import com.example.helloworldmvc.domain.enums.CommunityCategory;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,9 +34,11 @@ public class Community extends BaseEntity {
     private User user;
 
     @OneToMany(mappedBy = "community", cascade = CascadeType.ALL)
+    @BatchSize(size = 20)
     private List<File> fileList = new ArrayList<>();
 
     @OneToMany(mappedBy = "community", cascade = CascadeType.ALL)
+    @BatchSize(size = 20)
     private List<Comment> commentList = new ArrayList<>();
 
     public void setUser(User user) {

--- a/src/main/java/com/example/helloworldmvc/repository/CommunityRepository.java
+++ b/src/main/java/com/example/helloworldmvc/repository/CommunityRepository.java
@@ -3,12 +3,17 @@ package com.example.helloworldmvc.repository;
 import com.example.helloworldmvc.domain.Community;
 import com.example.helloworldmvc.domain.User;
 import com.example.helloworldmvc.domain.enums.CommunityCategory;
+import feign.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommunityRepository extends JpaRepository<Community, Long> {
     Page<Community> findAllByCommunityCategory(CommunityCategory category, Pageable pageable);
 
-    Page<Community> findAllByUserId(Long userId, Pageable pageable);
+//    Page<Community> findAllByUserId(Long userId, Pageable pageable);
+    @EntityGraph(attributePaths = {"user"})
+    Page<Community> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/helloworldmvc/web/dto/MyPageResponseDTO.java
+++ b/src/main/java/com/example/helloworldmvc/web/dto/MyPageResponseDTO.java
@@ -104,6 +104,8 @@ public class MyPageResponseDTO {
         String content;
         LocalDateTime uploadedAt;
         String category;
+        Long commentCnt;
+        String imageUrl;
     }
 
 


### PR DESCRIPTION
이미지 url,
댓글 수 표시

## 개요

자세한 로직
@EntityGraph로 user만 즉시 로딩하고 페이징은 정상 유지

@BatchSize로 commentList, fileList는 묶어서 조회 → N+1 방지

덕분에 안정적인 페이징 + DTO에서 필요한 모든 데이터 접근 가능


이유 :
Community → User는 조회 시 함께 가져와야 하며,

Community → Comment, File은 댓글 수와 대표 이미지 추출에 필요하지만

페이징 성능을 해치지 않고 N+1 문제 없이 처리해야 했음



## 작업사항

## 변경로직

### 변경 전

### 변경 후

## 사용방법

## 기타
